### PR TITLE
Feature/commonjs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+npm-debug.log
 bower_components
 node_modules

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,8 @@ module.exports = function(karma) {
             './node_modules/phantomjs-polyfill/bind-polyfill.js'
         ],
 
+        exclude: ['test/node.js'],
+
         preprocessors: {
             'src/**/*.js' : ['browserify'],
             'test/**/*.js': ['browserify']

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
   "main": "dist/clipboard.js",
   "browser": "src/clipboard.js",
   "browserify": {
-    "transform": [["babelify", {
-        "loose": "all"
-    }]]
+    "transform": [
+      [
+        "babelify",
+        {
+          "loose": "all"
+        }
+      ]
+    ]
   },
   "license": "MIT",
   "keywords": [
@@ -29,6 +34,7 @@
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-sinon": "^1.0.4",
+    "mocha": "^2.3.3",
     "phantomjs-polyfill": "0.0.1",
     "uglify": "^0.1.5"
   },
@@ -36,6 +42,8 @@
     "publish": "npm run build && npm run minify",
     "build": "browserify src/clipboard.js -s Clipboard -o dist/clipboard.js",
     "minify": "uglify -s dist/clipboard.js -o dist/clipboard.min.js",
-    "test": "karma start --single-run"
+    "test": "npm run mocha | npm run karma",
+    "karma": "karma start --single-run",
+    "mocha": "mocha test/node.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "1.3.0",
   "description": "Modern copy to clipboard. No Flash. Just 2kb",
   "repository": "zenorocha/clipboard.js",
-  "main": "src/clipboard.js",
+  "main": "dist/clipboard.js",
+  "browser": "src/clipboard.js",
+  "browserify": {
+    "transform": [["babelify", {
+        "loose": "all"
+    }]]
+  },
   "license": "MIT",
   "keywords": [
     "clipboard",
@@ -28,7 +34,7 @@
   },
   "scripts": {
     "publish": "npm run build && npm run minify",
-    "build": "browserify src/clipboard.js -s Clipboard -t [babelify --loose all] -o dist/clipboard.js",
+    "build": "browserify src/clipboard.js -s Clipboard -o dist/clipboard.js",
     "minify": "uglify -s dist/clipboard.js -o dist/clipboard.min.js",
     "test": "karma start --single-run"
   }

--- a/test/node.js
+++ b/test/node.js
@@ -1,0 +1,11 @@
+var assert = require('chai').assert;
+var browserify = require('browserify');
+
+describe('Node', function() {
+    it('should import the lib in a commonjs env without babel', function(done) {
+        browserify('./dist/clipboard.js').bundle(function(err) {
+            assert.equal(err, null);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
This PR adds support for node envs that uses browserify but does not uses babel as a transformer.

Updated tests, in this case I had to add Mocha and Chai for testing the node part, since karma was not built to test envs that are not browser based (correct me if I'm wrong). Don't know if this is the best approach, but was the simplest that I found.

This closes the issue https://github.com/zenorocha/clipboard.js/issues/15