### PR TITLE
Fix for default parameters (zenorocha/clipboard.js#20)

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -140,8 +140,8 @@ class ClipboardAction {
      * Sets the `action` to be performed which can be either 'copy' or 'cut'.
      * @param {String} action
      */
-    set action(action) {
-        this._action = action || 'copy';
+    set action(action = 'copy') {
+        this._action = action;
 
         if (this._action !== 'copy' && this._action !== 'cut') {
             throw new Error('Invalid "action" value, use either "copy" or "cut"');

--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -6,7 +6,7 @@ class ClipboardAction {
      * Initializes selection from either `text` or `target` property.
      * @param {Object} options
      */
-    constructor(options) {
+    constructor(options = {}) {
         this.action  = options.action;
         this.emitter = options.emitter;
         this.target  = options.target;

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -27,8 +27,7 @@ class Clipboard extends Emitter {
      * or a custom function that was passed in the constructor.
      * @param {Object} options
      */
-    resolveOptions(options) {
-        options = options || {};
+    resolveOptions(options = {}) {
 
         this.action = (typeof options.action === 'function') ? options.action : this.setAction;
         this.target = (typeof options.target === 'function') ? options.target : this.setTarget;

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -39,7 +39,8 @@ class Clipboard extends Emitter {
      * @param {Element} trigger
      */
     setAction(trigger) {
-        return trigger.getAttribute(prefix + 'action');
+        var action = trigger.getAttribute(prefix + 'action');
+        return action === null ? undefined : action;
     }
 
     /**

--- a/test/clipboard-action.js
+++ b/test/clipboard-action.js
@@ -36,7 +36,7 @@ describe('ClipboardAction', () => {
         it('should throw an error since neither "text" nor "target" were passed', done => {
             try {
                 new ClipboardAction({
-                    action: ''
+                    action: undefined
                 });
             }
             catch(e) {

--- a/test/clipboard-action.js
+++ b/test/clipboard-action.js
@@ -35,9 +35,7 @@ describe('ClipboardAction', () => {
 
         it('should throw an error since neither "text" nor "target" were passed', done => {
             try {
-                new ClipboardAction({
-                    action: undefined
-                });
+                new ClipboardAction();
             }
             catch(e) {
                 assert.equal(e.message, 'Missing required attributes, use either "target" or "text"');


### PR DESCRIPTION
Default parameters (introduced in zenorocha/clipboard.js#20) require `undefined` rather than other falsy values. `getAttribute` returns `null`, and we were passing in the empty string to the test.