### PR TITLE
Add .npmignore

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,9 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[package.json]
+indent_size = 2
+
+[bower.json]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,8 +18,5 @@ insert_final_newline = true
 [*.md]
 trim_trailing_whitespace = false
 
-[package.json]
-indent_size = 2
-
-[bower.json]
+[{package.json,bower.json}]
 indent_size = 2

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+/.*/
+/example/
+/test/
+/.*
+/bower.json
+/karma.conf.js

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,14 @@
   "description": "Modern copy to clipboard. No Flash. Just 2kb",
   "license": "MIT",
   "main": "dist/clipboard.js",
+  "ignore": [
+    "/.*/",
+    "/example/",
+    "/test/",
+    "/.*",
+    "/bower.json",
+    "/karma.conf.js"
+  ],
   "keywords": [
     "clipboard",
     "copy",


### PR DESCRIPTION
After installing locally `npm install ~/github/clipboard.js` it now has only essentials.

```
[nkbt@nkbt] clipboard $ find . | grep -v node_modules
.
./dist
./dist/clipboard.js
./dist/clipboard.min.js
./package.json
./README.md
./src
./src/clipboard-action.js
./src/clipboard.js
```