### PR TITLE
Fix discontiguous selection

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Example</title>
+    <style>
+        .copy {
+            display: inline-block;
+            padding: 2px 5px;
+
+            font: inherit;
+
+            border-radius: 5px;
+            background: rgba(0, 0, 0, 0.1);
+            cursor: default;
+        }
+
+        button.copy {
+            border: 1px solid rgba(0, 0, 0, 0.3);
+        }
+
+        #span, #input {
+            display: inline-block;
+            width: 100px;
+            padding: 2px 5px;
+            margin-right: 10px;
+
+            font: inherit;
+
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            border-radius: 5px;
+        }
+
+    </style>
+</head>
+<body>
+<input type="text" id="input" value="input">
+
+<span class="copy" data-clipboard-action="copy" data-clipboard-target="#input">
+    &lt;span&gt;
+</span>
+<button class="copy" data-clipboard-action="copy" data-clipboard-target="#input">
+    &lt;button&gt;
+</button>
+
+<br>
+<br>
+
+<span id="span">span</span>
+
+<span class="copy" data-clipboard-action="copy" data-clipboard-target="#span">
+    &lt;span&gt;
+</span>
+<button class="copy" data-clipboard-action="copy" data-clipboard-target="#span">
+    &lt;button&gt;
+</button>
+
+<br><br>
+
+<textarea cols="30" rows="10" placeholder="Paste here"></textarea>
+
+
+<script src="../dist/clipboard.js"></script>
+<script>
+    new Clipboard('.copy');
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "babelify": "^6.3.0",
     "browserify": "^11.2.0",
     "delegate-events": "^1.1.1",
-    "tiny-emitter": "^1.0.0"
+    "tiny-emitter": "^1.0.0",
+    "toggle-selection": "^1.0.3"
   },
   "devDependencies": {
     "karma": "^0.13.10",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify": "^11.2.0",
     "delegate-events": "^1.1.1",
     "tiny-emitter": "^1.0.0",
-    "toggle-selection": "^1.0.3"
+    "toggle-selection": "^1.0.4"
   },
   "devDependencies": {
     "karma": "^0.13.10",

--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -1,3 +1,5 @@
+import deselectCurrent from 'toggle-selection';
+
 /**
  * Inner class which performs selection from either `text` or `target`
  * properties and then executes copy or cut operations.
@@ -92,12 +94,15 @@ class ClipboardAction {
             this.selectedText = this.target.value;
         }
         else {
+            const reselectPrevious = deselectCurrent();
             let range = document.createRange();
             let selection = window.getSelection();
 
             range.selectNodeContents(this.target);
             selection.addRange(range);
             this.selectedText = selection.toString();
+
+            reselectPrevious();
         }
 
         this.copyText();


### PR DESCRIPTION
The reason for this error is because when we click on span browser makes another selection, so when we are trying to create selection in a different DOM branch, Chrome throws.

toggle-selection removes selection from currently clicked element so our problem is fixed.

# Before

![clipboad js-before](https://cloud.githubusercontent.com/assets/175264/10192888/f46c985e-67c2-11e5-85d2-4018a222e001.gif)

# After

![clipboad js-after](https://cloud.githubusercontent.com/assets/175264/10192893/fc806fd4-67c2-11e5-87fd-f760b94c5053.gif)

I wanted to write some tests but it seems like we need **real** integration tests (or at least some relatively close emulation), I could not reproduce this issue with unit-testing.