### PR TITLE
Added support for instantiating via elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "dependencies": {
     "delegate-events": "^1.1.1",
-    "tiny-emitter": "^1.0.0"
+    "tiny-emitter": "^1.0.0",
+    "component-event": "^0.1.4"
   },
   "devDependencies": {
     "babelify": "^6.3.0",

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,5 +1,6 @@
 import ClipboardAction from './clipboard-action';
 import Delegate from 'delegate-events';
+import event from 'component-event';
 import Emitter from 'tiny-emitter';
 
 const prefix = 'data-clipboard-';
@@ -17,7 +18,13 @@ class Clipboard extends Emitter {
         super();
 
         this.resolveOptions(options);
-        this.delegateClick(selector);
+        if (typeof selector === 'string') {
+            this.delegateClickToSelector(selector);
+        } else if (selector !== null && typeof selector === 'object') {
+            this.delegateClickToElement(selector);
+        } else {
+            throw new Error('`selector` should be a CSS selector string or elements itself.');
+        }
     }
 
     /**
@@ -35,8 +42,21 @@ class Clipboard extends Emitter {
      * Delegates a click event on the passed selector.
      * @param {String} selector
      */
-    delegateClick(selector) {
+    delegateClickToSelector(selector) {
         Delegate.bind(document.body, selector, 'click', (e) => this.initialize(e));
+    }
+
+    /**
+     * Delegates a click event on the passed element.
+     * @param {Object} element
+     */
+    delegateClickToElement(element) {
+        event.bind(document.body, 'click', (e) => {
+            e.delegateTarget = element;
+            if (e.delegateTarget) {
+                (e) => this.initialize(e);
+            }
+        });
     }
 
     /**

--- a/test/clipboard.js
+++ b/test/clipboard.js
@@ -1,6 +1,7 @@
 import Clipboard from '../src/clipboard';
 import ClipboardAction from '../src/clipboard-action';
 import Delegate from 'delegate-events';
+import Event from 'component-event';
 
 describe('Clipboard', () => {
     before(() => {
@@ -48,7 +49,7 @@ describe('Clipboard', () => {
         });
     });
 
-    describe('#delegateClick', function() {
+    describe('#delegateClickToSelector', function() {
         before(() => {
             global.spy = sinon.spy(Delegate, 'bind');
         });
@@ -59,13 +60,33 @@ describe('Clipboard', () => {
 
         it('should delegate a click event to the passed selector', () => {
             let element = document.body;
-            let selector = '.btn'
+            let selector = '.btn';
             let event = 'click';
 
             let clipboard = new Clipboard(selector);
 
             assert.ok(global.spy.calledOnce);
             assert.ok(global.spy.calledWith(element, selector, event));
+        });
+    });
+
+    describe('#delegateClickToElement', function() {
+        before(() => {
+            global.spy = sinon.spy(Event, 'bind');
+        });
+
+        after(() => {
+            global.spy.restore();
+        });
+
+        it('should delegate a click event to the passed element', () => {
+            let element = document.body;
+            let event = 'click';
+
+            let clipboard = new Clipboard(global.button);
+
+            assert.ok(global.spy.calledOnce);
+            assert.ok(global.spy.calledWith(element, event));
         });
     });
 


### PR DESCRIPTION
Instantiating clipboard.js with already selected DOM elements will be much easier when working with React.js like libraries.