### PR TITLE
Change Ctrl+C to ⌘C, because Safari.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This library relies on both [Selection](https://developer.mozilla.org/en-US/docs
 
 Although copy/cut operations with [execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) aren't supported on Safari yet (including mobile), it gracefully degrades because [Selection](https://developer.mozilla.org/en-US/docs/Web/API/Selection) is supported.
 
-That means you can show a tooltip saying `Copied!` when `success` event is called and `Press Ctrl+C to copy` when `error` event is called because the text is already selected.
+That means you can show a tooltip saying **Copied!** when `success` event is called and **Press ⌘C to copy** when `error` event is called because the text is already selected.
 
 For a live demonstration, open this [site](https://zenorocha.github.io/clipboard.js/) on Safari.
 


### PR DESCRIPTION
Hi,

When talking about graceful degradation in Safari, which currently only runs on Mac (the Windows version, AFAIK, is long abandoned), it makes sense to use the Command-C shortcut (⌘C), not Ctrl-C.

Here's what the Edit menu looks like throughout Mac OS, just for reference:
![screen shot 2015-10-01 at 9 41 20 am](https://cloud.githubusercontent.com/assets/140257/10214446/16f081b6-6821-11e5-89b2-12d6203c6be7.png)

(I also replaced `code formatting` with **bold**, because the propeller character ⌘ looks poorly in most of monospaced fonts.)