### PR TITLE
Added "build-watch" command. Added ".git" and "dist" directories to .gitignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
     "karma-sinon": "^1.0.4",
     "mocha": "^2.3.3",
     "phantomjs-polyfill": "0.0.1",
-    "uglify": "^0.1.5"
+    "uglify": "^0.1.5",
+    "watchify": "^3.4.0"
   },
   "scripts": {
     "build": "npm run build-debug && npm run build-min",
     "build-debug": "browserify src/clipboard.js -s Clipboard -o dist/clipboard.js",
     "build-min": "uglify -s dist/clipboard.js -o dist/clipboard.min.js",
+    "build-watch": "watchify src/clipboard.js -o dist/clipboard.js -v",
     "test": "npm run test-browser && npm run test-server",
     "test-browser": "karma start --single-run",
     "test-server": "mocha test/module-systems.js"


### PR DESCRIPTION
Added the .git and the dist/ directories to the .gitignore file
Added "build-watch" command based on watchify (https://github.com/substack/watchify), I've been using this for a while in my projects.
Removed dist/ directory from the cloned code. It can be built locally anyway so there is no use of it (eventually the dist/ folder can be created each time a new version is released)