### PR TITLE
Simplify Clipboard class

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -16,34 +16,20 @@ class Clipboard extends Emitter {
     constructor(selector, options) {
         super();
 
-        this.resolveOptions(options);
-        this.delegateClick(selector);
+        // Defines if attributes would be resolved using internal setter functions
+        // or custom functions that were passed in
+        this.action = (typeof options.action === 'function') ? options.action : this.getAction;
+        this.target = (typeof options.target === 'function') ? options.target : this.getTarget;
+        this.text   = (typeof options.text   === 'function') ? options.text   : this.getText;
+        Delegate.bind(document.body, selector, 'click', (e) => this.onClick(e));
     }
 
-    /**
-     * Defines if attributes would be resolved using internal setter functions
-     * or custom functions that were passed in the constructor.
-     * @param {Object} options
-     */
-    resolveOptions(options = {}) {
-        this.action = (typeof options.action === 'function') ? options.action : this.setAction;
-        this.target = (typeof options.target === 'function') ? options.target : this.setTarget;
-        this.text   = (typeof options.text   === 'function') ? options.text   : this.setText;
-    }
-
-    /**
-     * Delegates a click event on the passed selector.
-     * @param {String} selector
-     */
-    delegateClick(selector) {
-        Delegate.bind(document.body, selector, 'click', (e) => this.initialize(e));
-    }
 
     /**
      * Defines a new `ClipboardAction` on each click event.
      * @param {Event} e
      */
-    initialize(e) {
+    onClick(e) {
         if (this.clipboardAction) {
             this.clipboardAction = null;
         }
@@ -61,7 +47,7 @@ class Clipboard extends Emitter {
      * Sets the `action` lookup function.
      * @param {Element} trigger
      */
-    setAction(trigger) {
+    getAction(trigger) {
         if (!trigger.hasAttribute(prefix + 'action')) {
             return;
         }
@@ -73,7 +59,7 @@ class Clipboard extends Emitter {
      * Sets the `target` lookup function.
      * @param {Element} trigger
      */
-    setTarget(trigger) {
+    getTarget(trigger) {
         if (!trigger.hasAttribute(prefix + 'target')) {
             return;
         }
@@ -86,7 +72,7 @@ class Clipboard extends Emitter {
      * Sets the `text` lookup function.
      * @param {Element} trigger
      */
-    setText(trigger) {
+    getText(trigger) {
         if (!trigger.hasAttribute(prefix + 'text')) {
             return;
         }


### PR DESCRIPTION
Removing some of the OO cruft actually makes it clearer what's going on.  The separation of that constructor into two init functions obscured the fact that they were called only on initialisation.

Calling a method `initialize` when it is called on click, rather than when the class is initialized was very confusing, so I renamed it to `onClick`.

The `set...` methods where in fact getting the parameters, not setting anything, so I renamed them to `get...`.