### PR TITLE
Prevent FF < 41 scrolling to bottom of  page

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -56,6 +56,7 @@ class ClipboardAction {
         this.fakeElem = document.createElement('textarea');
         this.fakeElem.style.position = 'absolute';
         this.fakeElem.style.left = '-9999px';
+        this.fakeElem.style.top = document.body.scrollTop + 'px';
         this.fakeElem.setAttribute('readonly', '');
         this.fakeElem.value = this.text;
         this.selectedText = this.text;


### PR DESCRIPTION
In Firefox < 41, the selecting fakeElem.select() would cause the browser to scroll to the bottom of the page. 

By positioning fakeElem at the current scroll position, but still way out to the left, that no longer happens.