### PR TITLE
Fix for scrolling to top in unsupported firefox

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -56,7 +56,7 @@ class ClipboardAction {
         this.fakeElem = document.createElement('textarea');
         this.fakeElem.style.position = 'absolute';
         this.fakeElem.style.left = '-9999px';
-        this.fakeElem.style.top = document.body.scrollTop + 'px';
+        this.fakeElem.style.top = (window.pageYOffset || document.documentElement.scrollTop) + 'px';
         this.fakeElem.setAttribute('readonly', '');
         this.fakeElem.value = this.text;
         this.selectedText = this.text;


### PR DESCRIPTION
My previous fix didn't actually work. Instead of scrolling to the bottom it would scroll to the top, because it turns out document.body.scrollTop always returns 0 in Firefox.

This should work in most browsers.

See here: http://help.dottoro.com/ljnvjiow.php

Sorry for submitting a broken fix. I thought I'd tested it, but not well enough clearly.