### PR TITLE
fix npm3 build updating uglifyjs to version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
-  - 0.12
+  - stable

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "karma-sinon": "^1.0.4",
     "mocha": "^2.3.3",
     "phantomjs-polyfill": "0.0.1",
-    "uglify": "^0.1.5",
+    "uglify-js": "^2.4.24",
     "watchify": "^3.4.0"
   },
   "scripts": {
     "build": "npm run build-debug && npm run build-min",
     "build-debug": "browserify src/clipboard.js -s Clipboard -o dist/clipboard.js",
-    "build-min": "uglify -s dist/clipboard.js -o dist/clipboard.min.js",
+    "build-min": "uglifyjs dist/clipboard.js -m screw_ie8=true -c screw_ie8=true,unused=false -o dist/clipboard.min.js",
     "build-watch": "watchify src/clipboard.js -s Clipboard -o dist/clipboard.js -v",
     "test": "npm run test-browser && npm run test-server",
     "test-browser": "karma start --single-run",


### PR DESCRIPTION
UglifyJS 1 fails on NPM 3 since it needs grunt explicitly defined as dependency.

So, following #69 stats.

UglifyJS 1
```shell
$ gzipped dist/clipboard.min.js                  
Original size: 7.67 kB
Compressed size: 2.61 kB
Compression ratio: 33.99%
```

UglifyJS 2 (with mangle and screw ie8 option)
```shell
$ gzipped dist/clipboard.min.js
Original size: 7.70 kB
Compressed size: 2.60 kB
Compression ratio: 33.73%
```