### PR TITLE
Add Package metadata for Meteor.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,0 +1,12 @@
+// Package metadata for Meteor.js.
+
+Package.describe({
+  name: "zenorocha:clipboard",
+  summary: "Modern copy to clipboard. No Flash. Just 2kb.",
+  version: "1.4.0",
+  git: "https://github.com/zenorocha/clipboard.js"
+});
+
+Package.onUse(function(api) {
+  api.addFiles("dist/clipboard.min.js", "client");
+});


### PR DESCRIPTION
Adding this file meteor developers can easily include the package to the meteor assets pipeline.
Also you need to publish on [Atmosphere.js](atmospherejs.com). To do this, after merge this PR, install the [Meteor Toolbelt](https://www.meteor.com/install) and run `meteor publish --create` to publish the package.