### PR TITLE
Fixed for Firefox.

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -56,7 +56,7 @@ class ClipboardAction {
         this.fakeElem = document.createElement('textarea');
         this.fakeElem.style.position = 'absolute';
         this.fakeElem.style.left = '-9999px';
-        this.fakeElem.style.top = document.body.scrollTop + 'px';
+        this.fakeElem.style.top = ( window.pageYOffset || document.documentElement.scrollTop) + 'px';
         this.fakeElem.setAttribute('readonly', '');
         this.fakeElem.value = this.text;
         this.selectedText = this.text;


### PR DESCRIPTION
Scroll to top was buggy on Firefox, this should fix it by setting the Y offset. 