### PR TITLE
use event's currentTarget instead of target

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -47,10 +47,10 @@ class Clipboard extends Emitter {
         }
 
         this.clipboardAction = new ClipboardAction({
-            action  : this.action(e.target),
-            target  : this.target(e.target),
-            text    : this.text(e.target),
-            trigger : e.target,
+            action  : this.action(e.currentTarget),
+            target  : this.target(e.currentTarget),
+            text    : this.text(e.currentTarget),
+            trigger : e.currentTarget,
             emitter : this
         });
     }

--- a/test/clipboard.js
+++ b/test/clipboard.js
@@ -9,8 +9,14 @@ describe('Clipboard', () => {
         global.button.setAttribute('data-clipboard-text', 'foo');
         document.body.appendChild(global.button);
 
+        global.span = document.createElement('span');
+        global.span.innerHTML = 'bar';
+
+        global.button.appendChild(span);
+
         global.event = {
-            target: global.button
+            target: global.button,
+            currentTarget: global.button
         };
     });
 
@@ -60,6 +66,14 @@ describe('Clipboard', () => {
             let clipboard = new Clipboard('.btn');
 
             clipboard.onClick(global.event);
+            assert.instanceOf(clipboard.clipboardAction, ClipboardAction);
+        });
+
+        it('should use an event\'s currentTarget when not equal to target', () => {
+            let clipboard = new Clipboard('.btn');
+            let bubbledEvent = { target: global.span, currentTarget: global.button };
+
+            clipboard.onClick(bubbledEvent);
             assert.instanceOf(clipboard.clipboardAction, ClipboardAction);
         });
 


### PR DESCRIPTION
Updated `onClick` to use an event's `currentTarget` instead of `target` as this leads to errors when `target` and `currentTarget` are not the same (i.e. the event has already bubbled up).

Pull request in reference to https://github.com/zenorocha/clipboard.js/issues/119

EDIT: CI seems to be failing due to installation issues, tests pass locally.