### PR TITLE
Updates fake element to use visually hidden styles

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -56,9 +56,7 @@ export default class ClipboardAction {
         this.fakeHandler = document.body.addEventListener('click', () => this.removeFake());
 
         this.fakeElem = document.createElement('textarea');
-        this.fakeElem.style.position = 'absolute';
-        this.fakeElem.style.left = '-9999px';
-        this.fakeElem.style.top = (window.pageYOffset || document.documentElement.scrollTop) + 'px';
+        this.fakeElem.style.cssText = 'border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px';
         this.fakeElem.setAttribute('readonly', '');
         this.fakeElem.value = this.text;
 


### PR DESCRIPTION
This request changes styles given to the fake element that is used to copy text. These changes follow [the technique used by HTML5 Boilerplate](https://github.com/h5bp/html5-boilerplate/blob/v5.0.0/src/css/main.css#L
126-L140) which has been battle tested to protect against the most common element styles that might otherwise cause painting to the screen or expanding of the scrollable area when the textarea is added to the page (if and when it even takes so long as to possibly do these things).

Other benefits include:
- Freedom from reading the document scroll position (even with its clever IE8 fallback).
- The appropriate (and nifty use) of `style.cssText` rather than individual property assignments.
- The opportunity to work with you again.