### PR TITLE
Prevent auto-zooming on an iphone 

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -59,6 +59,7 @@ export default class ClipboardAction {
 
         this.fakeElem = document.createElement('textarea');
         this.fakeElem.style.position = 'absolute';
+        this.fakeElem.style.fontSize = '12pt'; // Prevent zooming on iPhones.
         this.fakeElem.style[ isRTL ? 'right' : 'left' ] = '-9999px';
         this.fakeElem.style.top = (window.pageYOffset || document.documentElement.scrollTop) + 'px';
         this.fakeElem.setAttribute('readonly', '');


### PR DESCRIPTION
Prevent auto-zooming on an iPhone by making the text area font appropriate size. Fixes Issue #180.