### PR TITLE
minor fix for fake elem

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -65,7 +65,7 @@ export default class ClipboardAction {
         this.fakeElem.style.padding = '0';
         this.fakeElem.style.margin = '0';
         // Move element out of screen horizontally
-        this.fakeElem.style.position = 'absolute';
+        this.fakeElem.style.position = 'fixed';
         this.fakeElem.style[ isRTL ? 'right' : 'left' ] = '-9999px';
         // Move element to the same position vertically
         this.fakeElem.style.top = (window.pageYOffset || document.documentElement.scrollTop) + 'px';


### PR DESCRIPTION
after call clipboard all page scrolls down. As i understand, its relates to fake element, cause its append to body.
I just set position to 'fixed' and now it works right. I think 'fixed' is more css-style independence then 'absolute'