### PR TITLE
Update readme.md with info on Safari support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,13 +164,7 @@ This library relies on both [Selection](https://developer.mozilla.org/en-US/docs
 
 | <img src="http://clipboardjs.com/assets/images/chrome.png" width="48px" height="48px" alt="Chrome logo"> | <img src="http://clipboardjs.com/assets/images/firefox.png" width="48px" height="48px" alt="Firefox logo"> | <img src="http://clipboardjs.com/assets/images/ie.png" width="48px" height="48px" alt="Internet Explorer logo"> | <img src="http://clipboardjs.com/assets/images/opera.png" width="48px" height="48px" alt="Opera logo"> | <img src="http://clipboardjs.com/assets/images/safari.png" width="48px" height="48px" alt="Safari logo"> |
 |:---:|:---:|:---:|:---:|:---:|
-| 42+ ✔ | 41+ ✔ | 9+ ✔ | 29+ ✔ | Nope ✘ |
-
-Although copy/cut operations with [execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) aren't supported on Safari yet (including mobile), it gracefully degrades because [Selection](https://developer.mozilla.org/en-US/docs/Web/API/Selection) is supported.
-
-That means you can show a tooltip saying `Copied!` when `success` event is called and `Press Ctrl+C to copy` when `error` event is called because the text is already selected.
-
-For a live demonstration, open this [site](http://clipboardjs.com) on Safari.
+| 42+ ✔ | 41+ ✔ | 9+ ✔ | 29+ ✔ | 19.1+ ✔ |
 
 ## License
 


### PR DESCRIPTION
Compliments #234

#234 also changes the Safari logo from b&w to colored.