### PR TITLE
Fix memory leak because of fakeHandlers

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -49,7 +49,7 @@ class ClipboardAction {
 
         this.removeFake();
 
-        this.fakeHandler = document.body.addEventListener('click', () => this.removeFake());
+        this.fakeHandler = document.body.addEventListener('click', () => this.removeFake()) || true;
 
         this.fakeElem = document.createElement('textarea');
         // Prevent zooming on iOS


### PR DESCRIPTION
addEventListener always returns undefined by spec
https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget-addEventListener