### PR TITLE
Fixed a minor bug that copy action is enabled even though a trigger button is disabled.

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -44,6 +44,10 @@ class Clipboard extends Emitter {
     onClick(e) {
         const trigger = e.delegateTarget || e.currentTarget;
 
+        if ("disabled" in trigger.attributes) {
+            return ;
+        }
+
         if (this.clipboardAction) {
             this.clipboardAction = null;
         }


### PR DESCRIPTION
Inserted a small logic to check if the target is disabled in order to avoid flashing the target textarea when the disabled button is clicked.