### PR TITLE
Make snippet buttons appear on kbd focus

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -181,7 +181,8 @@ textarea {
     top: 4px;
 }
 
-.snippet:hover .btn {
+.snippet:hover .btn,
+.snippet .btn:focus {
     opacity: 1;
 }
 


### PR DESCRIPTION
Currently, navigating just with the keyboard (TAB/SHIFT+TAB), the snippet buttons remain invisible. This forces the same change of opacity as hovering over the snippet with the mouse.