### PR TITLE
Move focus to trigger instead of simply blur()ing

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -130,11 +130,11 @@ class ClipboardAction {
     }
 
     /**
-     * Removes current selection and focus from `target` element.
+     * Moves focus away from `target` and back to the trigger, removes current selection.
      */
     clearSelection() {
-        if (this.target) {
-            this.target.blur();
+        if (this.trigger) {
+            this.trigger.focus();
         }
 
         window.getSelection().removeAllRanges();


### PR DESCRIPTION
`blur()` results in a loss/reset of keyboard focus, meaning keyboard users usually get thrown right back to the start of the page. Instead, this moves focus back to the trigger (which had the focus when the trigger was activated).
As with the proposed fix in https://github.com/zenorocha/clipboard.js/pull/418 this obviously results in the focus styles (like the default outline, unless suppressed) being applied to the trigger (see the related PR for rationale and future fix using `:focus-ring`)