### PR TITLE
Create composer.json for instalation with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "zenorocha/clipboardjs",
-  "description": "Modern copy to clipboard. No Flash. Just 3kb gzipped 📋 https://clipboardjs.com",
+  "description": "Modern copy to clipboard. No Flash. Just 3kb gzipped https://clipboardjs.com",
   "type": "component",
   "homepage": "https://clipboardjs.com/",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "zenorocha/clipboardjs",
+  "description": "Modern copy to clipboard. No Flash. Just 3kb gzipped 📋 https://clipboardjs.com",
+  "type": "component",
+  "homepage": "https://clipboardjs.com/",
+  "authors": [
+    {
+      "name": "Zeno Rocha",
+      "url": "http://zenorocha.com/"
+    }
+  ],
+  "require": {
+    "robloach/component-installer": "*"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "dist/clipboard.js"
+      ],
+      "files": [
+        "dist/clipboard.min.js"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The installation is much simpler with Composer and https://github.com/RobLoach/component-installer

After merged you can test it:
```
composer config repositories.zenorocha-clipboardjs vcs "https://github.com/zenorocha/clipboard.js/"
composer require zenorocha/clipboardjs:dev-master
```
Before merged you can test using my git fork.

Composer creates a "components" folder that contains the "clipboardjs" whith all files spec in "files" of composer.json.
You can then register the "package" at https://packagist.org In this way the installation would be simpler:
`composer require zenorocha/clipboardjs:dev-master`