### PR TITLE
Add option to stop event propagation on click

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -28,6 +28,7 @@ class Clipboard extends Emitter {
         this.target    = (typeof options.target    === 'function') ? options.target    : this.defaultTarget;
         this.text      = (typeof options.text      === 'function') ? options.text      : this.defaultText;
         this.container = (typeof options.container === 'object')   ? options.container : document.body;
+        this.stopPropagation = options.stopPropagation;
     }
 
     /**
@@ -57,6 +58,10 @@ class Clipboard extends Emitter {
             trigger   : trigger,
             emitter   : this
         });
+
+        if (this.stopPropagation) {
+            e.stopPropagation();
+        }
     }
 
     /**


### PR DESCRIPTION
I need a way to stop the click event on a clipboard icon from propagating to it's container.  I'm open to any suggestions, this PR is just to get discussion started hopefully.  Thanks.  (also see #350)