### PR TITLE
Ability to limit triggering event to ctrl+click and get event details in custom handler functions

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -28,6 +28,7 @@ class Clipboard extends Emitter {
         this.target    = (typeof options.target    === 'function') ? options.target    : this.defaultTarget;
         this.text      = (typeof options.text      === 'function') ? options.text      : this.defaultText;
         this.container = (typeof options.container === 'object')   ? options.container : document.body;
+        this.ctrlClick = (typeof options.ctrl      === 'boolean')  ? options.ctrl      : false;
     }
 
     /**
@@ -45,16 +46,20 @@ class Clipboard extends Emitter {
     onClick(e) {
         const trigger = e.delegateTarget || e.currentTarget;
 
+        // if ctr+click is required but not keypressed die silently
+        if (this.ctrlClick && !e.ctrlKey) return;
+
         if (this.clipboardAction) {
             this.clipboardAction = null;
         }
 
         this.clipboardAction = new ClipboardAction({
-            action    : this.action(trigger),
-            target    : this.target(trigger),
-            text      : this.text(trigger),
+            action    : this.action(trigger, e),
+            target    : this.target(trigger, e),
+            text      : this.text(trigger, e),
             container : this.container,
             trigger   : trigger,
+            event     : e,
             emitter   : this
         });
     }

--- a/test/clipboard.js
+++ b/test/clipboard.js
@@ -27,6 +27,7 @@ describe('Clipboard', () => {
     describe('#resolveOptions', () => {
         before(() => {
             global.fn = () => {};
+            global.ctrl = true;
         });
 
         it('should set action as a function', () => {
@@ -65,6 +66,14 @@ describe('Clipboard', () => {
             let clipboard = new Clipboard('.btn');
 
             assert.equal(document.body, clipboard.container);
+        });
+
+        it('should set ctrlClick as a boolean', () => {
+            let clipboard = new Clipboard('.btn', {
+                ctrl: global.ctrl
+            });
+
+            assert.equal(global.ctrl, clipboard.ctrlClick);
         });
     });
 
@@ -105,6 +114,15 @@ describe('Clipboard', () => {
                 assert.equal(e.message, 'Invalid "target" value, use a valid Element');
                 done();
             }
+        });
+
+        it('should not create a new instance of ClipboardAction if ctrlClick required but not pressed', () => {
+            let clipboard = new Clipboard('.btn', {
+                ctrl: global.ctrl
+            });
+
+            clipboard.onClick(global.event);
+            assert.notInstanceOf(clipboard.clipboardAction, ClipboardAction);
         });
     });
 


### PR DESCRIPTION
Hello, 

I needed this functionality for a project. It's quite possible to bind clipboard.js to non-action (so to speak) HTML elements such as `<td>`s or `<span>`s but in that case click to copy might not be desirable.

The feature works as follows. You add option `ctrl:true` to the constructor options:

```javascript
import Clipboard from 'clipboard'

let clip = new Clipboard('.clip', {
  ctrl: true
})
```

And now elements with `.clipboard` CSS class only copy to clipboard if `ctrl` key was pressed when the element was clicked.

- Added Ctr+click option to options { ctrl: true }
- Custom handlers can now receive firing event as a second parameter if some logic should be applied based in it's value
- `ClipboardAction` object now contains event as a property