### PR TITLE
Supply a simple `#copy` api on plain text

### DIFF
--- a/dist/clipboard.js
+++ b/dist/clipboard.js
@@ -1,3 +1,9 @@
+/*!
+ * clipboard.js v1.7.1
+ * https://zenorocha.github.io/clipboard.js
+ *
+ * Licensed MIT © Zeno Rocha
+ */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Clipboard = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 var DOCUMENT_NODE_TYPE = 9;
 

--- a/dist/clipboard.js
+++ b/dist/clipboard.js
@@ -1,9 +1,3 @@
-/*!
- * clipboard.js v1.7.1
- * https://zenorocha.github.io/clipboard.js
- *
- * Licensed MIT © Zeno Rocha
- */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Clipboard = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 var DOCUMENT_NODE_TYPE = 9;
 
@@ -672,7 +666,10 @@ module.exports = E;
             var _this = _possibleConstructorReturn(this, (Clipboard.__proto__ || Object.getPrototypeOf(Clipboard)).call(this));
 
             _this.resolveOptions(options);
-            _this.listenClick(trigger);
+
+            if (trigger) {
+                _this.listenClick(trigger);
+            }
             return _this;
         }
 
@@ -735,6 +732,20 @@ module.exports = E;
                 }
             }
         }, {
+            key: 'copy',
+            value: function copy() {
+                var text = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+
+                if (!text.length) return;
+
+                this.clipboardAction = new _clipboardAction2.default({
+                    action: 'copy',
+                    text: text,
+                    container: document.body,
+                    emitter: this
+                });
+            }
+        }, {
             key: 'defaultText',
             value: function defaultText(trigger) {
                 return getAttributeValue('text', trigger);
@@ -742,7 +753,9 @@ module.exports = E;
         }, {
             key: 'destroy',
             value: function destroy() {
-                this.listener.destroy();
+                if (this.listener) {
+                    this.listener.destroy();
+                }
 
                 if (this.clipboardAction) {
                     this.clipboardAction.destroy();

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -15,7 +15,10 @@ class Clipboard extends Emitter {
         super();
 
         this.resolveOptions(options);
-        this.listenClick(trigger);
+
+        if (trigger) {
+          this.listenClick(trigger);
+        }
     }
 
     /**
@@ -96,6 +99,21 @@ class Clipboard extends Emitter {
     }
 
     /**
+     * Executes copy on given text without the need for a DOM element
+     * @param {String} text
+     */
+    copy(text = '') {
+      if (!text.length) return
+
+      this.clipboardAction = new ClipboardAction({
+          action    : 'copy',
+          text      : text,
+          container : document.body,
+          emitter   : this
+      });
+    }
+
+    /**
      * Default `text` lookup function.
      * @param {Element} trigger
      */
@@ -107,7 +125,9 @@ class Clipboard extends Emitter {
      * Destroy lifecycle.
      */
     destroy() {
-        this.listener.destroy();
+        if (this.listener) {
+          this.listener.destroy();
+        }
 
         if (this.clipboardAction) {
             this.clipboardAction.destroy();

--- a/test/clipboard.js
+++ b/test/clipboard.js
@@ -129,4 +129,20 @@ describe('Clipboard', () => {
             assert.equal(clipboard.clipboardAction, null);
         });
     });
+
+    describe("#copy", () => {
+      it('should create a new instance of ClipboardAction', () => {
+          let clipboard = new Clipboard();
+
+          clipboard.copy('Hello World');
+          assert.instanceOf(clipboard.clipboardAction, ClipboardAction);
+      });
+
+      it('should not create a new instance of ClipboardAction when no text is given', () => {
+        let clipboard = new Clipboard();
+
+        clipboard.copy();
+        assert.equal(clipboard.clipboardAction, null);
+      })
+    })
 });


### PR DESCRIPTION
Hi,

I used clipboard.js In two recent projects which in both, I needed to copy some text to the clipboard without having a button or a trigger. 

For example, there's a list of items where users can use the keyboard to navigate up and down, and on pressing 'Enter', the text in the item should be copied to the clipboard. I couldn't find a way to do it with the current API (which requires a DOM element to be clicked on) so I dug into the code and looked for ways to do it. Luckily, the code is very clean and well written so it was easy to implement such behavior

Here's the gist of what you can do now:
```js
// no arguments needed on initialization
let clipboard = new Clipboard() 

// callbacks still work as expected
clipboard.on('success', () => {
  console.log('Copied!')
})

// Simple API to copy text on the fly
clipboard.copy('hello world')
```

It might not be aligned with the philosophy of clipboard.js, but I think it's simple enough and expands the flexibility quite a lot!