### PR TITLE
Don't claim to support ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "zenorocha/clipboard.js",
   "license": "MIT",
   "main": "dist/clipboard.js",
-  "module": "dist/clipboard.js",
   "keywords": [
     "clipboard",
     "copy",


### PR DESCRIPTION
Clipboard.js doesn't support ESM, its package.json shouldn't claim it does.

Reference: https://github.com/rollup/rollup/wiki/pkg.module