### PR TITLE
Fix module signature

### DIFF
--- a/src/clipboard-action.js
+++ b/src/clipboard-action.js
@@ -201,4 +201,4 @@ class ClipboardAction {
     }
 }
 
-module.exports = ClipboardAction;
+export default ClipboardAction;

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -132,4 +132,4 @@ function getAttributeValue(suffix, element) {
     return element.getAttribute(attribute);
 }
 
-module.exports = Clipboard;
+export default Clipboard;


### PR DESCRIPTION
Source files use both harmony (for `import`) and CommonJS (`module.exports`) modules signatures.

When `webpack` imports such files with both signatures, it cause error when `module` become read-only, and using `module.exports` throws Exception.

Bug was introduced in #190