### PR TITLE
npm install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ That's why clipboard.js exists.
 You can get it on npm.
 
 ```
-npm install clipboard --save
+npm install clipboard 
 ```
 
 Or if you're not into package management, just [download a ZIP](https://github.com/zenorocha/clipboard.js/archive/master.zip) file.


### PR DESCRIPTION
save option is no longer needed, [look here](https://stackoverflow.com/questions/19578796/what-is-the-save-option-for-npm-install)
removing it might get rid of unnecessary confusion many will face like me, just an opinion

npm install clipboard ~~--save~~