### PR TITLE
feat adding es5 as target for webpack compilation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ Licensed MIT © Zeno Rocha`;
 module.exports = {
   entry: './src/clipboard.js',
   mode: 'production',
+  target: ['web', 'es5'],
   output: {
     filename: production ? 'clipboard.min.js' : 'clipboard.js',
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/zenorocha/clipboard.js/blob/master/contributing.md#proposing-pull-requests
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**


This PR should close #737 #738,

what happened was that once we update to use webpack5 the target option was not specified and the build was created with arrow functions, breaking the es5 builds, by targeting the build we can avoid that.

https://webpack.js.org/blog/2020-10-10-webpack-5-release/#improved-code-generation 