### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -5,9 +5,12 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
+
+env:
+  FORCE_COLOR: 2
 
 jobs:
   build:
@@ -20,13 +23,12 @@ jobs:
         # For now is not possible to target LTS verssions =/ check progress here https://github.com/actions/setup-node/issues/26
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm run lint
-    - run: npm test
-
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm run lint
+      - run: npm test


### PR DESCRIPTION
* add `FORCE_COLOR: 2` so that we get colored output
* update to `actions/setup-node@v2`
* fix formatting

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/zenorocha/clipboard.js/blob/master/contributing.md#proposing-pull-requests
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

* Please checkout the non-whitespace diff: https://github.com/zenorocha/clipboard.js/pull/752/files?w=1
* The build step seems unneeded since it already runs on `ci`, but maybe it's as a precaution
* The lint step could be a separate workflow assuming there's npm caching, so that it runs only once
* The `test:types` script does not run on CI ATM