### PR TITLE
fix(onClick-trigger-target): trigger is null

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -68,7 +68,7 @@ class Clipboard extends Emitter {
    * @param {Event} e
    */
   onClick(e) {
-    const trigger = e.delegateTarget || e.currentTarget;
+    const trigger = e.delegateTarget || e.currentTarget || e.target;
     const selectedText = ClipboardActionDefault({
       action: this.action(trigger),
       container: this.container,


### PR DESCRIPTION
trigger is null if call an async function between "click the button" and " new Clipboard()"

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/zenorocha/clipboard.js/blob/master/contributing.md#proposing-pull-requests
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In onClick function, we get "trigger" from "e.delegateTarget || e.currentTarget" I get from MDN about `e.currentTarget`.
> The currentTarget read-only property of the Event interface identifies the current target for the event, as the event traverses the DOM

** as the event traverses the DOM**

if I click the button, then I call an async function, and after that `new Clipboard()`.  `trigger` and `e.currentTarget` would be null.
We'll get an error

![image](https://user-images.githubusercontent.com/77786952/125803027-b29f4ec5-e776-498e-9a4a-a15ac6d8a99a.png)

This is my first "pr" for open-resource project, I'm sorry about it has only one line.


