### PR TITLE
Fix #805 don't `blur()` the trigger after a clipboard action

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -86,7 +86,6 @@ class Clipboard extends Emitter {
         if (trigger) {
           trigger.focus();
         }
-        document.activeElement.blur();
         window.getSelection().removeAllRanges();
       },
     });

--- a/test/clipboard.js
+++ b/test/clipboard.js
@@ -171,15 +171,16 @@ describe('Clipboard', () => {
   });
 
   describe('#clearSelection', () => {
-    it('should clear text selection', (done) => {
+    it('should clear text selection without moving focus', (done) => {
       let clipboard = new Clipboard('.btn');
 
       clipboard.on('success', (e) => {
+        e.clearSelection();
+
         let selectedElem = document.activeElement;
         let selectedText = window.getSelection().toString();
 
-        e.clearSelection();
-
+        assert.equal(selectedElem, e.trigger);
         assert.equal(selectedText, '');
 
         done();

--- a/test/clipboard.js
+++ b/test/clipboard.js
@@ -171,7 +171,7 @@ describe('Clipboard', () => {
   });
 
   describe('#clearSelection', () => {
-    it('should remove focus from target and text selection', (done) => {
+    it('should clear text selection', (done) => {
       let clipboard = new Clipboard('.btn');
 
       clipboard.on('success', (e) => {
@@ -180,7 +180,6 @@ describe('Clipboard', () => {
 
         e.clearSelection();
 
-        assert.equal(selectedElem, document.body);
         assert.equal(selectedText, '');
 
         done();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

This PR reintroduces the behavior that used to be in clipboard.js following https://github.com/zenorocha/clipboard.js/pull/419 but that has since been reverted for some reason. As such, after a clipboard action, focus will remain/be on the trigger element, rather than the body. If applications rely on the focus to be gone/removed from the trigger button, they'll need to adapt to this.

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] New/updated tests are included

I didn't target v2.x branch because it looks wildly out of date.

**Other information:**

I'm not too hot on writing tests, so rather than just removing the check to see if focus is now on the body, it should probably explicitly check that focus remained on the trigger. However, not quite sure how to do that - my knowledge of test harnesses etc is pretty basic.

Closes #805 